### PR TITLE
Fix typos and indentation

### DIFF
--- a/docs/NTUNotes/Hung-Yu/Game Theory for Wireless Network/Coalitional Games for Computation Offloading in NOMA-Enabled Multi-Access Edge Computing.md
+++ b/docs/NTUNotes/Hung-Yu/Game Theory for Wireless Network/Coalitional Games for Computation Offloading in NOMA-Enabled Multi-Access Edge Computing.md
@@ -31,7 +31,7 @@ source: <https://ieeexplore.ieee.org/document/8917566>
 		- superpose signals from various users
 	- receiver side
 		- interference cancellation to decode the signals
-        - accommodate more UEs than the number of available subcarriers
+  	- accommodate more UEs than the number of available subcarriers
 	- key tech for massive connectivities
 		- e.g. IoT
 	- can enable grant-free acess & flexible scheduling  → more UEs served simultneously → reduce latency

--- a/docs/NTUNotes/Hung-Yu/Game Theory for Wireless Network/Coalitional Games for Computation Offloading in NOMA-Enabled Multi-Access Edge Computing.md
+++ b/docs/NTUNotes/Hung-Yu/Game Theory for Wireless Network/Coalitional Games for Computation Offloading in NOMA-Enabled Multi-Access Edge Computing.md
@@ -31,7 +31,7 @@ source: <https://ieeexplore.ieee.org/document/8917566>
 		- superpose signals from various users
 	- receiver side
 		- interference cancellation to decode the signals
-	- accomodate more UEs than the number of available subcarriers
+        - accommodate more UEs than the number of available subcarriers
 	- key tech for massive connectivities
 		- e.g. IoT
 	- can enable grant-free acess & flexible scheduling  → more UEs served simultneously → reduce latency

--- a/docs/NTUNotes/Junior/Spanish/Spanish.md
+++ b/docs/NTUNotes/Junior/Spanish/Spanish.md
@@ -10,14 +10,14 @@ layout: meth
 
 Long press on a letter and select or press the following key combinations:
 
--   á — Option + e, a.
--   Á — Option + e, Shift + a.
--   é — Option + e, e.
--   É — Option + e, Shift + e.
--   í — Option + e, i.
--   Í — Option + e, Shift + i.
--   ñ — Option + n, n.
--   Ñ — Option + n, Shift + n.
+- á — Option + e, a.
+- Á — Option + e, Shift + a.
+- é — Option + e, e.
+- É — Option + e, Shift + e.
+- í — Option + e, i.
+- Í — Option + e, Shift + i.
+- ñ — Option + n, n.
+- Ñ — Option + n, Shift + n.
 
 ## Present Participle / Gerundio
 
@@ -2441,10 +2441,10 @@ Messi dejó FC Barcelona para PSG, un club plástico, por que Bartomeu, el expre
 - conducir = drive
 - alcohol /alcol/
 - alojar = accommodate
-- aloharse = stay
-	- aloharse en un hotel
-- hotel accomodation plan
-	- pensión completa = full-board accomodation (all meals)
+- alojarse = stay
+        - alojarse en un hotel
+- hotel accommodation plan
+        - pensión completa = full-board accommodation (all meals)
 	- media pensión (breakfast & lunch)
 	- alojamiento y desayuno (only breakfast)
 - maleta = suitcase


### PR DESCRIPTION
## Summary
- correct accommodate typo in Game Theory notes
- fix Spanish vocabulary typos and hotel accommodation lines
- make the first bullet list indentation consistent in Spanish notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b0848dfc8323a3af1dd154179536