### PR TITLE
Fix typos and formatting in notes

### DIFF
--- a/docs/NTUNotes/Hung-Yu/Game Theory for Wireless Network/Coalitional Games for Computation Offloading in NOMA-Enabled Multi-Access Edge Computing.md
+++ b/docs/NTUNotes/Hung-Yu/Game Theory for Wireless Network/Coalitional Games for Computation Offloading in NOMA-Enabled Multi-Access Edge Computing.md
@@ -31,10 +31,10 @@ source: <https://ieeexplore.ieee.org/document/8917566>
 		- superpose signals from various users
 	- receiver side
 		- interference cancellation to decode the signals
-	- accomodate more UEs than the number of available subcarriers
+	- accommodate more UEs than the number of available subcarriers
 	- key tech for massive connectivities
 		- e.g. IoT
-	- can enable grant-free acess & flexible scheduling  → more UEs served simultneously → reduce latency
+	- can enable grant-free access & flexible scheduling  → more UEs served simultaneously → reduce latency
 	- better than OMA
 		- can utilize all subcarriers channels
 		- fairness provisioning (?)

--- a/docs/NTUNotes/Hung-Yu/Game Theory for Wireless Network/Game Theory for Wireless Networks.md
+++ b/docs/NTUNotes/Hung-Yu/Game Theory for Wireless Network/Game Theory for Wireless Networks.md
@@ -26,7 +26,7 @@ use [Game Theory](Game%20Theory) to solve resource allocation problems in wirele
 - [Distributed Dynamic Resource Management and Pricing in the IoT Systems With Blockchain-as-a-Service and UAV-Enabled Mobile Edge Computing](Distributed%20Dynamic%20Resource%20Management%20and%20Pricing%20in%20the%20IoT%20Systems%20With%20Blockchain-as-a-Service%20and%20UAV-Enabled%20Mobile%20Edge%20Computing)
 - Task Offloading and Resource Allocation in Mobile Edge Computing System
 	- each user has different priority
-	- priority is a funciton of local computation resource
+	- priority is a function of local computation resource
 	- local computation resource in uniform distribution
 	- different random sequence comparison
 		- ![[game-theory-for-wireless-networks-1.png]]

--- a/docs/NTUNotes/Junior/Computer Networks/Computer Networks.md
+++ b/docs/NTUNotes/Junior/Computer Networks/Computer Networks.md
@@ -205,7 +205,7 @@ Starband, HughesNet
 	- link-layer switches
 - store-and-forward transmission
 	- receive the entire packet → transmit
-	- store/buffer the bits until the entire packet is recieved
+	- store/buffer the bits until the entire packet is received
 	- forward/transmit the packet onto the outbound link
 	- delay (see [Delay Loss Throughput](#Delay%20Loss%20Throughput))
 		- a packet of $L$ bits (L=packet length)
@@ -997,9 +997,9 @@ so there're many security problems now
 
 #### RTT & Timeout
 ##### Estimated RTT
-- RTT = rount trip time
+- RTT = round trip time
 	- time from data sent to ACK received
-- SampleRTT = the RTT of the newly recieved ACK
+- SampleRTT = the RTT of the newly received ACK
 	- won't measure retransmissions
 	- measured about once every RTT
 - $EstimatedRTT = (1-\alpha)\cdot EstimatedRTT+\alpha\cdot SampleRTT$
@@ -1018,7 +1018,7 @@ so there're many security problems now
 ##### Timeout
 
 $TimeoutInterval = EstimatedRTT+4\cdot DevRTT$
-- timeout interval should > Estimated RTT, and the more fluntuating RTT is, the bigger the margin
+- timeout interval should > Estimated RTT, and the more fluctuating RTT is, the bigger the margin
 - TimeoutInterval will double after timeout, follow the formula again after receiving next segment
 	- exponential backoff
 
@@ -1031,7 +1031,7 @@ $TimeoutInterval = EstimatedRTT+4\cdot DevRTT$
 
 ##### cumulative ACK
 - hybrid of [[#Go Back N GBN]] & [[#Selective Repeat SR]]
-	- reciever ACK the ==next bit== to be received
+	- receiver ACK the ==next bit== to be received
 	- differences with GBN
 		- TCP will buffer out-of-order segments
 		- TCP uses cumulative ACK

--- a/docs/NTUNotes/Junior/Industrial Organization/Industrial Organization HW.md
+++ b/docs/NTUNotes/Junior/Industrial Organization/Industrial Organization HW.md
@@ -169,7 +169,7 @@ $profit=(P-MC)(1-\dfrac{P}{400})10M=P(1-\dfrac{P}{400})10M$
 profit maximized when P = 200
 
 #### (4)
-if sell seperately, total profit = 200x5Mx2 = 2B
+if sell separately, total profit = 200x5Mx2 = 2B
 
 ![[industrial-organization-hw-23.png]]
 ![[industrial-organization-hw-24.png]]
@@ -191,7 +191,7 @@ profit = 2.177B - 500M > 0, so yes
 #### (7)
 sell at a price so that total profit = 500M
 
-- if sell seperately
+- if sell separately
 	- $2P(1-\dfrac{P}{400})10M=500M$  
 	- $P^2-400P+10000=0$
 	- P=26.795 (373.02 不合)

--- a/docs/NTUNotes/Junior/Macroeconomics/Macroeconomics.md
+++ b/docs/NTUNotes/Junior/Macroeconomics/Macroeconomics.md
@@ -3179,7 +3179,7 @@ The result is the same whether the government funds the purchase through lump-su
 	- consumption down, labor up, wage down -> current utility down
 	- firm investment down -> future output down -> future consumption down -> future utility down
 	- however, the model leaves out the fact that government purchases have externality irl
-- government purchase is not the determining force to economic flunctuations
+- government purchase is not the determining force to economic fluctuations
 	- empirical data: GDP $\propto$ $1/r$, GDP $\propto C, I, w$ 
 	- RBC analysis of government purchase up:  GDP $\propto$ $r$, GDP $\propto 1/C, 1/I, 1/w$ 
 

--- a/docs/NTUNotes/Junior/Spanish/Spanish.md
+++ b/docs/NTUNotes/Junior/Spanish/Spanish.md
@@ -2441,10 +2441,10 @@ Messi dejó FC Barcelona para PSG, un club plástico, por que Bartomeu, el expre
 - conducir = drive
 - alcohol /alcol/
 - alojar = accommodate
-- aloharse = stay
-	- aloharse en un hotel
-- hotel accomodation plan
-	- pensión completa = full-board accomodation (all meals)
+- alojarse = stay
+	- alojarse en un hotel
+- hotel accommodation plan
+	- pensión completa = full-board accommodation (all meals)
 	- media pensión (breakfast & lunch)
 	- alojamiento y desayuno (only breakfast)
 - maleta = suitcase

--- a/docs/NTUNotes/Senior/Principle of Macroeconomics/Principle of Macroeconomics.md
+++ b/docs/NTUNotes/Senior/Principle of Macroeconomics/Principle of Macroeconomics.md
@@ -130,7 +130,7 @@ concave utility funcion -> risk averse
 
 $$u(E(X))>E(u(X))$$
 
-See this utility vs. wealth diagram, with the green line being the person's utility funciton.
+See this utility vs. wealth diagram, with the green line being the person's utility function.
 
 ![[principle-of-macroeconomics-9.png]]
 
@@ -322,10 +322,10 @@ $$NCO=NX$$
 
 ## Ch33 Aggregate Demand and Supply
 
-### Economic Flunctations
+### Economic Fluctuations
 
-- economic flunctuations are irregular and unpredictable
-- most macroeconomic quantities flunctuate together
+- economic fluctuations are irregular and unpredictable
+- most macroeconomic quantities fluctuate together
 - when output falls, unemployment rises
 
 ### Aggregated Demand

--- a/docs/NTUNotes/Sophomore/Data Structure/Data Structure.md
+++ b/docs/NTUNotes/Sophomore/Data Structure/Data Structure.md
@@ -442,7 +442,7 @@ Bell (W2)
     - sum of ASCII
       - len = 8 → 只會用到 127x8 個 slot
     - ![[data-structure-49.png]]
-- seperate chaining 
+- separate chaining
   - 可每個 slot 存 linked list
     - collision → 加到後面
     - insertion O(1)

--- a/docs/NTUNotes/polly/Internet Scale User-Generated Live Video Streaming - The Twitch Case.md
+++ b/docs/NTUNotes/polly/Internet Scale User-Generated Live Video Streaming - The Twitch Case.md
@@ -31,7 +31,7 @@ parent: polly
 
 ## Stream Hosting Strategy
 
-- for a channel, the amount of servers allocated flunctuated with current viewer counts
+- for a channel, the amount of servers allocated fluctuated with current viewer counts
 	- ![[internet-scale-user-generated-live-video-streaming---the-twitch-case-2.png]]
 - each region scales independently, based on the viewer counts of the region
 - cross continent hosting strat

--- a/docs/NTUNotes/polly/Zmap.md
+++ b/docs/NTUNotes/polly/Zmap.md
@@ -313,7 +313,7 @@ parent: polly
 - regional biases existed
 	- some websites are only accessible from 1 country
 		- not significant at global scale
-	- may be more severe at countries with seperate Internet infrastructure
+	- may be more severe at countries with separate Internet infrastructure
 		- e.g. China & Russia
 
 ## polly's comments

--- a/docs/obs_autolink/Firefox.md
+++ b/docs/obs_autolink/Firefox.md
@@ -13,7 +13,7 @@ parent: Miscellaneous
 
 Set the environmental variable `MOZ_USE_XINPUT2` as `1`.
 
-For exmaple, in `/etc/profile.d/use-xinput2.sh` (create if don't exist)
+For example, in `/etc/profile.d/use-xinput2.sh` (create if it doesn't exist)
 
 ```
 export MOZ_USE_XINPUT2=1

--- a/docs/software-development/Go.md
+++ b/docs/software-development/Go.md
@@ -66,7 +66,7 @@ You may see a lot of older Internet guides using `go get`, but it's deprecated. 
 
 ### Install current project's dependencies
 
-Auto check your codes and update `go.mod` and install all required dependecies in `go.mod` to `GOMODACHE` if haven't
+Automatically check your code, update `go.mod`, and install all required dependencies in `go.mod` to `GOMODCACHE` if you haven't
 
 ```
 go mod tidy
@@ -775,7 +775,7 @@ func (r projectRepository) GetProjectID(ctx context.Context, projectID uuid.UUID
 }
 ```
 
-If you look at its raw query, it still makes 2 seperate query for `Project` & `Incident` table, but at least you don't have to handle it youself.
+If you look at its raw query, it still makes 2 separate queries for `Project` & `Incident` table, but at least you don't have to handle it yourself.
 
 ### Set a nullable field back to null
 

--- a/docs/software-development/Python.md
+++ b/docs/software-development/Python.md
@@ -674,7 +674,7 @@ with open('deployment.yaml', 'r') as f:
     deploy = yaml.safe_load(f)
 ```
 
-For multiple document combined (with `---` seperator, see [this](https://stackoverflow.com/questions/47593695/)):
+For multiple documents combined (with `---` separator, see [this](https://stackoverflow.com/questions/47593695/)):
 
 ```python
 import yaml


### PR DESCRIPTION
## Summary
- correct typos in markdown notes
- adjust phrasing and word choice for clarity
- restore original indentation for changed lines

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6842b541dc388323a42da6b3294d145c